### PR TITLE
Revert "Undeclare ledgerx.protocol as a namesapce package"

### DIFF
--- a/ledgerx/protocol/__init__.py
+++ b/ledgerx/protocol/__init__.py
@@ -1,3 +1,4 @@
 # Copyright 2014 NYBX Inc.
 # All rights reserved.
 
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         url = 'https://ledgerx.com',
         zip_safe = True,
         install_requires = __filter_requires(REQS_PATH),
-        namespace_packages = ['ledgerx'],
+        namespace_packages = ['ledgerx', 'ledgerx.protocol'],
         packages = find_packages(exclude=['*test*']),
         test_suite = 'ledgerx.protocol.tester.load_test_suite',
         platforms = 'POSIX',


### PR DESCRIPTION
Declare `ledgerx.protocol` as a namespace package. (Please tag as 0.3.5 once merged.)

This reverts commit 25c91995dd54ec9c1ff0977da6a76b91283e9a32.

Conflicts:
	setup.py